### PR TITLE
Use print preview instead of print

### DIFF
--- a/src/webcnoaddressbar.xul
+++ b/src/webcnoaddressbar.xul
@@ -179,7 +179,7 @@
                  />
   <toolbarbutton id="wc-print" class="toolbarbutton-1 chromeclass-toolbar-additional"
                  tooltiptext="&printButton.tooltip;"
-                 command="cmd_print"
+                 command="cmd_printPreview"
                  hidden="true"
                  />
 


### PR DESCRIPTION
So the code in Mozilla did print for Mac and printPreview for everyone else.

Please verify this before you check it in.
