### PR TITLE
Use a chrome blacklist so we're particular about what we allow

### DIFF
--- a/components/fileBlockService.js
+++ b/components/fileBlockService.js
@@ -11,6 +11,9 @@ FileBlock.prototype = {
   tempDir: null,
   // List of domains for the whitelist
   whitelist: [],
+  // Chrome pages that should not be shown
+  chromeBlacklist: ["browser", "mozapps", "marionette", "specialpowers",
+                    "branding", "alerts"],
   initialize: function() {
     this.appDir = Services.io.newFileURI(Services.dirsvc.get("CurProcD", Ci.nsIFile)).spec;
     var profileDir = Services.dirsvc.get("ProfD", Ci.nsIFile);
@@ -77,7 +80,11 @@ FileBlock.prototype = {
       if (aRequestOrigin &&
           (aRequestOrigin.spec == "chrome://browser/content/browser.xul" ||
           aRequestOrigin.scheme == "moz-nullprincipal")) {
-        return Ci.nsIContentPolicy.ACCEPT;
+        for (var i=0; i < this.chromeBlacklist.length; i++) {
+          if (aContentLocation.host == this.chromeBlacklist[i]) {
+            return Ci.nsIContentPolicy.REJECT_REQUEST;
+          }
+        }
       }
       // All chrome requests come through here, so we have to allow them
       // (Like loading the main browser window for instance)


### PR DESCRIPTION
So the reason that printing was not working is because I was way to zealous in my chrome blocking.

I should allow any chrome that is NOT on the blacklist.

Printing in particular was "global" and they should always be allowed.

I picked the blacklist based on URLs that people shouldn't try to load.
